### PR TITLE
Various fixes

### DIFF
--- a/aws-prowler-report/README.md
+++ b/aws-prowler-report/README.md
@@ -39,6 +39,12 @@ This takes a while.... ~30m-1h. DO NOT close the lid of your laptop.
 
 This outputs a JSON file to `./output` to be used in the next step.
 
+If you want to only run the report for specific regions, [use the `-f` option](https://github.com/prowler-cloud/prowler#regions) like so:
+
+```sh
+docker run -it --rm --name prowler -v $(pwd)/output:/prowler/output --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_SESSION_TOKEN toniblyx/prowler -g cislevel2 -M json -f us-east-1,ap-northeast-3
+```
+
 ### Convert the Report to HTML and then render to PDF
 
 You will need node installed with the version specified in `.tool-versions`

--- a/aws-prowler-report/assets/template.pug
+++ b/aws-prowler-report/assets/template.pug
@@ -30,11 +30,22 @@ html(lang='en',style="-webkit-print-color-adjust: exact;")
                 table-layout:fixed
             }
 
+            .summary {
+                width: 100%;
+                border-collapse: collapse;
+            }
+
+            .summary, .summary th, .summary td {
+                border: 1px solid black;
+                padding: 1em;
+            }
+
             .title {
                 text-align: center;
                 font-weight: bold;
                 font-size: 4pc;
             }
+
             .customer {
                 text-align: center;
                 font-weight: bold;
@@ -98,7 +109,7 @@ html(lang='en',style="-webkit-print-color-adjust: exact;")
         p.customer #{customer}
         br
         br
-        p.subtitle Account Number #{json[0]["Account Number"]}
+        p.subtitle Account Number #{audit[0]["Account Number"]}
         p.subtitle Generated on #{moment().format('MM/DD/YYYY')}
         div.container.break-before.break-after
             h1 Overview
@@ -113,9 +124,26 @@ html(lang='en',style="-webkit-print-color-adjust: exact;")
             p
                 | This report is provided on an "AS IS" basis.  It is provided without warranty of any kinds and disclaims all warranties whether express or implied. Test Double is not associated
                 | with the Center for Internet Security.  This assessment is not certified by the Center for Internet Security.
-        div.container.center
+        div.container.center.break-before
+            h2 Summary of Failed Checks
+        div.container
+            table.summary
+                tr
+                    th Region
+                    th Critical
+                    th High
+                    th Medium
+                    th Low
+                each region in summary
+                    tr
+                        td= region.region
+                        td= region.Critical || 0
+                        td= region.High || 0
+                        td= region.Medium || 0
+                        td= region.Low || 0
+        div.container.center.break-before
             h2 Results
-        each c in json
+        each c in audit
             div.container
                 table.table.mb-10
                     tr.mb-10

--- a/aws-prowler-report/index.js
+++ b/aws-prowler-report/index.js
@@ -48,12 +48,29 @@ for (a in grouped){
 // Sort the entire audit array by severity
 audit.sort((a,b) => SeveritySortHash[a.Severity] - SeveritySortHash[b.Severity])
 
+let summary = _.sortBy(
+  _.map(
+    _.groupBy(
+      _.filter(json, a => a.Status.toUpperCase() == 'FAIL'),
+      "Region"
+    ),
+    (json_r, region) => {
+      return {region:region ,..._.countBy(json_r, "Severity")}
+    }
+  )
+, 'region')
+
 // Uncomment this if you want to see the intermediate step for the JSON
 // fs.writeFileSync('report.json', JSON.stringify(audit,  null, 2));
 
 // Render HTML
 const compiledFunction = pug.compileFile('./assets/template.pug');
-fs.writeFileSync('./output/output.html', compiledFunction({'json': audit, 'moment': moment, 'customer' : customer}));
+fs.writeFileSync('./output/output.html', compiledFunction({
+  summary: summary,
+  audit: audit,
+  moment: moment,
+  customer: customer
+}));
 
 // HTML -> PDF
 let options = { format: 'A4', path: out };


### PR DESCRIPTION
These changes are to address #14 

- Added a summary table near the top that shows failed checks by their region and by severity level
- Added instructions on how to only run the report for selected regions

Summary looks like this:

<img width="646" alt="image" src="https://user-images.githubusercontent.com/621712/197298310-7aeb844f-d1d1-43fb-984d-4fc869a49ab6.png">
